### PR TITLE
fix shortcut in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,5 +19,5 @@ You can run formatting manually from contextual menu:
 From tools menu:
 ![!menu](./docs/menu.gif)
 
-Or using keyboard shortcut <kbd>Ctrl Shift L</kbd> on PC and <kbd>⌘ ⇧ L</kbd> on Mac
+Or using keyboard shortcut <kbd>Ctrl Shift P</kbd> on PC and <kbd>⌘ ⇧ P</kbd> on Mac
 ![!shortcut](./docs/shortcut.gif)


### PR DESCRIPTION
The correct shortcut seems to use `P` and not `L`. 
`P` is also visible in the animated gif in the readme.